### PR TITLE
PricingRule 具象クラスの value メソッドを抽象クラスに移動する

### DIFF
--- a/src/domain/PriceCalculator.php
+++ b/src/domain/PriceCalculator.php
@@ -24,18 +24,18 @@ class PriceCalculator
 
         $prices = [
             GeneralMemberRule::class => [
-                ScheduleType::MOVIE_DAY    => '1000',
-                ScheduleType::WEEKDAY      => '1000',
-                ScheduleType::WEEKDAY_LATE => '1000',
-                ScheduleType::WEEKEND      => '1000',
-                ScheduleType::WEEKEND_LATE => '1000',
+                ScheduleType::MOVIE_DAY()->getKey()    => '1000',
+                ScheduleType::WEEKDAY()->getKey()      => '1000',
+                ScheduleType::WEEKDAY_LATE()->getKey() => '1000',
+                ScheduleType::WEEKEND()->getKey()      => '1000',
+                ScheduleType::WEEKEND_LATE()->getKey() => '1000',
             ],
             RegularRule::class => [
-                ScheduleType::MOVIE_DAY    => '1800',
-                ScheduleType::WEEKDAY      => '1300',
-                ScheduleType::WEEKDAY_LATE => '1800',
-                ScheduleType::WEEKEND      => '1300',
-                ScheduleType::WEEKEND_LATE => '1100',
+                ScheduleType::MOVIE_DAY()->getKey()    => '1800',
+                ScheduleType::WEEKDAY()->getKey()      => '1300',
+                ScheduleType::WEEKDAY_LATE()->getKey() => '1800',
+                ScheduleType::WEEKEND()->getKey()      => '1300',
+                ScheduleType::WEEKEND_LATE()->getKey() => '1100',
             ],
         ];
 

--- a/src/domain/PricingRules/AbstractPricingRule.php
+++ b/src/domain/PricingRules/AbstractPricingRule.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace CinemaTicketPricing\PricingRules;
+
+use CinemaTicketPricing\TicketPrice;
+use CinemaTicketPricing\TicketPriceDeterminants;
+use CinemaTicketPricing\PriceFinder;
+
+class AbstractPricingRule implements PricingRuleInterface
+{
+    private $determinants;
+
+    private $prices;
+
+    public function __construct(TicketPriceDeterminants $determinants, array $prices)
+    {
+        $this->determinants = $determinants;
+        $this->prices       = $prices;
+    }
+
+    public function match(): bool
+    {
+        return true;
+    }
+
+    public function value(): TicketPrice
+    {
+        $finder = new PriceFinder($this->determinants);
+        $price = $finder->find($this->prices);
+        // finder->find で数値を返す必要あり
+        return new TicketPrice($price);
+    }
+}

--- a/src/domain/PricingRules/AbstractPricingRule.php
+++ b/src/domain/PricingRules/AbstractPricingRule.php
@@ -6,9 +6,9 @@ use CinemaTicketPricing\TicketPrice;
 use CinemaTicketPricing\TicketPriceDeterminants;
 use CinemaTicketPricing\PriceFinder;
 
-class AbstractPricingRule implements PricingRuleInterface
+abstract class AbstractPricingRule implements PricingRuleInterface
 {
-    private $determinants;
+    protected $determinants;
 
     private $prices;
 

--- a/src/domain/PricingRules/AbstractPricingRule.php
+++ b/src/domain/PricingRules/AbstractPricingRule.php
@@ -18,10 +18,7 @@ abstract class AbstractPricingRule implements PricingRuleInterface
         $this->prices       = $prices;
     }
 
-    public function match(): bool
-    {
-        return true;
-    }
+    abstract public function match(): bool;
 
     public function value(): TicketPrice
     {

--- a/src/domain/PricingRules/GeneralMemberRule.php
+++ b/src/domain/PricingRules/GeneralMemberRule.php
@@ -6,25 +6,15 @@ namespace CinemaTicketPricing\PricingRules;
 use CinemaTicketPricing\TicketPrice;
 use CinemaTicketPricing\TicketPriceDeterminants;
 
-class GeneralMemberRule implements PricingRuleInterface
+class GeneralMemberRule extends AbstractPricingRule implements PricingRuleInterface
 {
-    private $determinants;
-
-    private $prices;
-
     public function __construct(TicketPriceDeterminants $determinants, array $prices)
     {
-        $this->determinants = $determinants;
-        $this->prices       = $prices;
+        parent::__construct($determinants, $prices);
     }
 
     public function match(): bool
     {
         return true;
-    }
-
-    public function value(): TicketPrice
-    {
-        return new TicketPrice(1000);
     }
 }

--- a/src/domain/PricingRules/GeneralMemberRule.php
+++ b/src/domain/PricingRules/GeneralMemberRule.php
@@ -3,15 +3,8 @@ declare(strict_types=1);
 
 namespace CinemaTicketPricing\PricingRules;
 
-use CinemaTicketPricing\TicketPriceDeterminants;
-
 class GeneralMemberRule extends AbstractPricingRule
 {
-    public function __construct(TicketPriceDeterminants $determinants, array $prices)
-    {
-        parent::__construct($determinants, $prices);
-    }
-
     public function match(): bool
     {
         return true;

--- a/src/domain/PricingRules/GeneralMemberRule.php
+++ b/src/domain/PricingRules/GeneralMemberRule.php
@@ -3,10 +3,9 @@ declare(strict_types=1);
 
 namespace CinemaTicketPricing\PricingRules;
 
-use CinemaTicketPricing\TicketPrice;
 use CinemaTicketPricing\TicketPriceDeterminants;
 
-class GeneralMemberRule extends AbstractPricingRule implements PricingRuleInterface
+class GeneralMemberRule extends AbstractPricingRule
 {
     public function __construct(TicketPriceDeterminants $determinants, array $prices)
     {

--- a/src/domain/PricingRules/RegularRule.php
+++ b/src/domain/PricingRules/RegularRule.php
@@ -6,28 +6,15 @@ use CinemaTicketPricing\TicketPrice;
 use CinemaTicketPricing\TicketPriceDeterminants;
 use CinemaTicketPricing\PriceFinder;
 
-class RegularRule implements PricingRuleInterface
+class RegularRule extends AbstractPricingRule implements PricingRuleInterface
 {
-    private $determinants;
-
-    private $prices;
-
     public function __construct(TicketPriceDeterminants $determinants, array $prices)
     {
-        $this->determinants = $determinants;
-        $this->prices       = $prices;
+        parent::__construct($determinants, $prices);
     }
 
     public function match(): bool
     {
         return true;
-    }
-
-    public function value(): TicketPrice
-    {
-        $finder = new PriceFinder($this->determinants);
-        $price = $finder->find($this->prices);
-        // finder->find で数値を返す必要あり
-        return new TicketPrice($price);
     }
 }

--- a/src/domain/PricingRules/RegularRule.php
+++ b/src/domain/PricingRules/RegularRule.php
@@ -2,15 +2,8 @@
 
 namespace CinemaTicketPricing\PricingRules;
 
-use CinemaTicketPricing\TicketPriceDeterminants;
-
 class RegularRule extends AbstractPricingRule
 {
-    public function __construct(TicketPriceDeterminants $determinants, array $prices)
-    {
-        parent::__construct($determinants, $prices);
-    }
-
     public function match(): bool
     {
         return true;

--- a/src/domain/PricingRules/RegularRule.php
+++ b/src/domain/PricingRules/RegularRule.php
@@ -2,11 +2,9 @@
 
 namespace CinemaTicketPricing\PricingRules;
 
-use CinemaTicketPricing\TicketPrice;
 use CinemaTicketPricing\TicketPriceDeterminants;
-use CinemaTicketPricing\PriceFinder;
 
-class RegularRule extends AbstractPricingRule implements PricingRuleInterface
+class RegularRule extends AbstractPricingRule
 {
     public function __construct(TicketPriceDeterminants $determinants, array $prices)
     {


### PR DESCRIPTION
#3 
- PriceCalculator で配列の key を getKey で持つよう修正
- 各 Rule のクラスの処理を AbstractPricingRule 
  - value の処理を abstract クラスに持たせる